### PR TITLE
Investigate modal opening bug

### DIFF
--- a/src/components/checkout/security-modal.tsx
+++ b/src/components/checkout/security-modal.tsx
@@ -89,7 +89,7 @@ export function SecurityModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">
       <div className="bg-zinc-100 rounded-lg max-w-md w-full mx-4 p-4 flex flex-col space-y-4">
         <h2 className="font-bold text-2xl text-center">Verificação de Segurança</h2>
         <p className="text-zinc-600 text-center">


### PR DESCRIPTION
Increase SecurityModal overlay z-index to fix rendering issue.

A transformed or animated ancestor can create a stacking context that causes a `fixed` element with `z-50` to render beneath other elements. Increasing the z-index to `z-[9999]` ensures the modal sits on top of all other elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb36763a-8c17-417e-a57e-7ea9ff81c746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb36763a-8c17-417e-a57e-7ea9ff81c746">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

